### PR TITLE
Feature/event iteration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.11'
+          - '1.12'
           - 'pre'
         os:
           - ubuntu-latest

--- a/src/ChronoSim.jl
+++ b/src/ChronoSim.jl
@@ -6,6 +6,7 @@ include("generator_interface.jl")
 include("ObservedState/ObservedState.jl")
 include("events.jl")
 include("generators.jl")
+include("placetoevent.jl")
 include("framework.jl")
 
 end

--- a/src/ObservedState/observed_physical.jl
+++ b/src/ObservedState/observed_physical.jl
@@ -92,8 +92,9 @@ macro observedphysical(struct_name, struct_block)
     end
 
     # Create the struct definition
+    ObservedPhysicalType = ObservedPhysical
     struct_def = quote
-        mutable struct $struct_name <: ObservedPhysical
+        mutable struct $struct_name <: $ObservedPhysicalType
             $(user_fields...)
             obs_modified::Vector{Tuple}
             obs_read::Vector{Tuple}

--- a/src/depnet.jl
+++ b/src/depnet.jl
@@ -101,6 +101,15 @@ function getplace_rate(net::DependencyNetwork{E}, place) where {E}
     get(net.place, place, (en=Set{E}(), ra=Set{E}())).ra
 end
 
+
+function getevent_enable(net::DependencyNetwork{E}, event) where {E}
+    get(net.event, event, (en=Set{E}(), ra=Set{E}())).en
+end
+
+function getevent_rate(net::DependencyNetwork{E}, event) where {E}
+    get(net.event, event, (en=Set{E}(), ra=Set{E}())).ra
+end
+
 export DepNetNaive
 
 """

--- a/src/framework.jl
+++ b/src/framework.jl
@@ -12,11 +12,10 @@ export SimulationFSM
 mutable struct SimulationFSM{State,Sampler,CK}
     physical::State
     sampler::Sampler
-    eventgen::GeneratorSearch
     immediategen::GeneratorSearch
     when::Float64
     rng::Xoshiro
-    depnet::DependencyNetwork{CK}
+    event_dependency::EventDependency{CK}
     enabled_events::Dict{CK,SimEvent}
     enabling_times::Dict{CK,Float64}
     observer
@@ -105,11 +104,10 @@ function SimulationFSM(
     return SimulationFSM{typeof(physical),typeof(sampler),ClockKey}(
         physical,
         sampler,
-        generator_searches["timed"],
         generator_searches["immediate"],
         0.0,
         randgen,
-        DependencyNetwork{ClockKey}(),
+        EventDependency{ClockKey}(generator_searches["timed"]),
         Dict{ClockKey,SimEvent}(),
         Dict{ClockKey,Float64}(),
         observer,
@@ -117,7 +115,9 @@ function SimulationFSM(
 end
 
 
-checksim(sim::SimulationFSM) = @assert keys(sim.enabled_events) == keys(sim.depnet.event)
+function checksim(sim::SimulationFSM)
+    @assert keys(sim.enabled_events) == keys(sim.event_dependency.depnet.event)
+end
 
 
 function rate_reenable(sim::SimulationFSM, event, clock_key)
@@ -133,44 +133,6 @@ function rate_reenable(sim::SimulationFSM, event, clock_key)
 end
 
 
-function process_generated_events_from_changes(sim::SimulationFSM, fired_event_key, changed_places)
-    over_generated_events(sim.eventgen, sim.physical, fired_event_key, changed_places) do newevent
-        evtkey = clock_key(newevent)
-        if evtkey ∉ keys(sim.enabled_events)
-            precond = capture_state_reads(sim.physical) do
-                result = precondition(newevent, sim.physical)
-                if isnothing(result)
-                    error("""The precondition for $newevent returned `nothing` which may
-                        mean that the precondition function doesn't return a true/false or
-                        that the interface stub for precondition was called because the
-                        function signature for $(newevent)'s precondition doesn't match.
-                        """)
-                end
-                return result
-            end
-            if precond.result
-                input_places = precond.reads
-                sim.enabled_events[evtkey] = newevent
-                sim.enabling_times[evtkey] = sim.when
-                reads_result = capture_state_reads(sim.physical) do
-                    enabling_spec = enable(newevent, sim.physical, sim.when)
-                    if length(enabling_spec) != 2
-                        error("""The enable() function for $newevent should return a
-                            distribution and a time. This one returns $enabling_spec.
-                            """)
-                    end
-                    (dist, enable_time) = enabling_spec
-                    enable!(sim.sampler, evtkey, dist, enable_time, sim.when, sim.rng)
-                end
-                rate_deps = reads_result.reads
-                @debug "Evtkey $(evtkey) with enable deps $(input_places) rate deps $(rate_deps)"
-                add_event!(sim.depnet, evtkey, input_places, rate_deps)
-            end
-        end
-    end
-end
-
-
 """
     deal_with_changes(sim::SimulationFSM)
 
@@ -178,7 +140,7 @@ An event changed the state. This function modifies events
 to respond to changes in state.
 """
 function deal_with_changes(
-    sim::SimulationFSM{State,Sampler,CK}, fired_event, changed_places
+    sim::SimulationFSM{State,Sampler,CK}, fired_event, fired_event_keys, changed_places
 ) where {State,Sampler,CK}
     # This function starts with enabled events. It ends with enabled events.
     # Let's look at just those events that depend on changed places.
@@ -189,51 +151,79 @@ function deal_with_changes(
     #
     # Sort for reproducibility run-to-run.
     @debug "Fired $(fired_event) changed $(changed_places)"
-    if !isempty(changed_places)
-        clock_toremove = CK[]
-        cond_affected = union((getplace_enable(sim.depnet, cp) for cp in changed_places)...)
-        rate_affected = union((getplace_rate(sim.depnet, cp) for cp in changed_places)...)
+    isempty(changed_places) && return nothing
 
-        for check_clock_key in sort(collect(cond_affected))
-            event = sim.enabled_events[check_clock_key]
+    clock_toremove = CK[]
+    over_event_invariants(sim.event_dependency, sim, fired_event_keys, changed_places) do event
+        check_clock_key = clock_key(event)
+        reads_result = capture_state_reads(sim.physical) do
+            precondition(event, sim.physical)
+        end
+        cond_result = reads_result.result
+        cond_places = reads_result.reads
+        # While the current dependency network knows if it was enabled, we check it here
+        # in case we use a dependency graph that doesn't depend on the current state.
+        event_was_enabled = check_clock_key ∈ keys(sim.enabled_events)
+
+        if event_was_enabled && !cond_result
+            push!(clock_toremove, check_clock_key)
+        elseif !event_was_enabled && cond_result
+            sim.enabled_events[check_clock_key] = event
+            sim.enabling_times[check_clock_key] = sim.when
             reads_result = capture_state_reads(sim.physical) do
-                precondition(event, sim.physical)
+                enabling_spec = enable(event, sim.physical, sim.when)
+                if length(enabling_spec) != 2
+                    error("""The enable() function for $check_clock_key should return a
+                        distribution and a time. This one returns $enabling_spec.
+                        """)
+                end
+                (dist, enable_time) = enabling_spec
+                enable!(sim.sampler, check_clock_key, dist, enable_time, sim.when, sim.rng)
             end
-            cond_result = reads_result.result
-            cond_places = reads_result.reads
-
-            if !cond_result
-                push!(clock_toremove, check_clock_key)
+            rate_deps = reads_result.reads
+            @debug "Evtkey $(check_clock_key) with enable deps $(cond_places) rate deps $(rate_deps)"
+            add_event!(sim.event_dependency, check_clock_key, cond_places, rate_deps)
+        elseif event_was_enabled && cond_result
+            # Every time we check an invariant after a state change, we must
+            # re-calculate how it depends on the state. For instance,
+            # A can move right. Then A moves down. Then A can still move
+            # right, but its moving right now depends on a different space
+            # to the right. This is because a "move right" event is defined
+            # relative to a state, not on a specific, absolute set of places.
+            if cond_places != getevent_enable(sim.event_dependency, check_clock_key)
+                # Then you get new places.
+                rate_deps = rate_reenable(sim, event, check_clock_key)
+                add_event!(sim.event_dependency, check_clock_key, cond_places, rate_deps)
             else
-                # Every time we check an invariant after a state change, we must
-                # re-calculate how it depends on the state. For instance,
-                # A can move right. Then A moves down. Then A can still move
-                # right, but its moving right now depends on a different space
-                # to the right. This is because a "move right" event is defined
-                # relative to a state, not on a specific set of places.
-                if cond_places != getplace_enable(sim.depnet, check_clock_key)
-                    # Then you get new places.
-                    rate_deps = rate_reenable(sim, event, check_clock_key)
-                    add_event!(sim.depnet, check_clock_key, cond_places, rate_deps)
-                    if check_clock_key in rate_affected
-                        delete!(rate_affected, check_clock_key)
+                rate_deps = getevent_rate(sim.event_dependency, check_clock_key)
+                @assert eltype(rate_deps) == eltype(changed_places)
+                if !isdisjoint(rate_deps, changed_places)
+                    new_rate_deps = rate_reenable(sim, event, check_clock_key)
+                    if rate_deps != new_rate_deps
+                        add_event!(
+                            sim.event_dependency, check_clock_key, cond_places, new_rate_deps
+                        )
                     end
                 end
             end
+            # else event wasn't enabled and it isn't now.
         end
+    end
 
-        for rate_clock_key in sort(collect(rate_affected))
-            event = sim.enabled_events[rate_clock_key]
-            rate_deps = rate_reenable(sim, event, rate_clock_key)
-            cond_deps = getplace_enable(sim.depnet, rate_clock_key)
-            add_event!(sim.depnet, rate_clock_key, cond_deps, rate_deps)
+    disable_clocks!(sim, clock_toremove)
+
+    over_event_rates(sim.event_dependency, sim, fired_event_keys, changed_places) do event
+        rate_clock_key = clock_key(event)
+        rate_event = get(sim.enabled_events, rate_clock_key, nothing)
+        if !isnothing(rate_event)
+            rate_deps = getevent_rate(sim.event_dependency, rate_clock_key)
+            new_rate_deps = rate_reenable(sim, rate_event, rate_clock_key)
+            if rate_deps != new_rate_deps
+                cond_deps = getevent_enable(sim.event_dependency, rate_clock_key)
+                add_event!(sim.event_dependency, rate_clock_key, cond_deps, new_rate_deps)
+            end
+            # else it won't be in sim.event_dependency either so nothing to add/delete.
         end
-
-        # Split the loop over changed_places so that the first part disables clocks
-        # and the second part creates new ones. We do this because two clocks
-        # can have the SAME key but DIFFERENT dependencies. For instance, "move left"
-        # will depend on different board places after the piece has moved.
-        disable_clocks!(sim, clock_toremove)
     end
 end
 
@@ -246,7 +236,7 @@ function disable_clocks!(sim::SimulationFSM, clock_keys)
         delete!(sim.enabled_events, clock_done)
         delete!(sim.enabling_times, clock_done)
     end
-    remove_event!(sim.depnet, clock_keys)
+    remove_event!(sim.event_dependency, clock_keys)
 end
 
 
@@ -281,8 +271,7 @@ function fire!(sim::SimulationFSM, when, what)
     # Break the invariant that state and events are consistent.
     changed_places = modify_state!(sim, event)
     disable_clocks!(sim, [what])
-    deal_with_changes(sim, event, changed_places)
-    process_generated_events_from_changes(sim, what, changed_places)
+    deal_with_changes(sim, event, what, changed_places)
     checksim(sim)
     # Invariant for states and events is restored, so show the result.
     sim.observer(sim.physical, when, event, changed_places)
@@ -304,8 +293,8 @@ function initialize!(init_evt, callback::Function, sim::SimulationFSM)
     changes_result = capture_state_changes(sim.physical) do
         callback(sim.physical, sim.when, sim.rng)
     end
-    deal_with_changes(sim, init_evt, changes_result.changes)
-    process_generated_events_from_changes(sim, clock_key(init_evt), changes_result.changes)
+    what = []
+    deal_with_changes(sim, init_evt, what, changes_result.changes)
     checksim(sim)
     sim.observer(sim.physical, sim.when, init_evt, changes_result.changes)
 end

--- a/src/framework.jl
+++ b/src/framework.jl
@@ -293,8 +293,8 @@ function initialize!(init_evt, callback::Function, sim::SimulationFSM)
     changes_result = capture_state_changes(sim.physical) do
         callback(sim.physical, sim.when, sim.rng)
     end
-    what = []
-    deal_with_changes(sim, init_evt, what, changes_result.changes)
+    # The `what` event is type Nothing to signal it isn't an event.
+    deal_with_changes(sim, init_evt, nothing, changes_result.changes)
     checksim(sim)
     sim.observer(sim.physical, sim.when, init_evt, changes_result.changes)
 end

--- a/src/framework.jl
+++ b/src/framework.jl
@@ -294,7 +294,7 @@ function fire!(sim::SimulationFSM, when, what)
     # Break the invariant that state and events are consistent.
     changed_places = modify_state!(sim, event)
     disable_clocks!(sim, [what])
-    remove_event!(event_dependency, [what])
+    remove_event!(sim.event_dependency, [what])
     deal_with_changes(sim, sim.event_dependency, what, changed_places)
     checksim(sim)
     # Invariant for states and events is restored, so show the result.

--- a/src/framework.jl
+++ b/src/framework.jl
@@ -234,6 +234,7 @@ function deal_with_changes(
     end
 
     disable_clocks!(sim, clock_toremove)
+    remove_event!(event_dependency, clock_toremove)
 
     over_event_rates(event_dependency, sim, fired_event_keys, changed_places) do event
         rate_clock_key = clock_key(event)
@@ -259,7 +260,6 @@ function disable_clocks!(sim::SimulationFSM, clock_keys)
         delete!(sim.enabled_events, clock_done)
         delete!(sim.enabling_times, clock_done)
     end
-    remove_event!(event_dependency, clock_keys)
 end
 
 
@@ -294,6 +294,7 @@ function fire!(sim::SimulationFSM, when, what)
     # Break the invariant that state and events are consistent.
     changed_places = modify_state!(sim, event)
     disable_clocks!(sim, [what])
+    remove_event!(event_dependency, [what])
     deal_with_changes(sim, sim.event_dependency, what, changed_places)
     checksim(sim)
     # Invariant for states and events is restored, so show the result.

--- a/src/framework.jl
+++ b/src/framework.jl
@@ -5,7 +5,7 @@ using CompetingClocks:
 
 using Distributions
 
-export SimulationFSM
+export SimulationFSM, ModelDefinitionError
 
 ########## The Simulation Finite State Machine (FSM)
 

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -111,7 +111,7 @@ place_patterns(gs::GeneratorSearch) = collect(keys(gs.byarray))
 function over_generated_events(
     f::Function, generators::GeneratorSearch, physical, event_key, changed_places
 )
-    if !isempty(event_key)
+    if !isnothing(event_key) && !isempty(event_key)
         event_args = event_key[2:end]
         for from_event in get(generators.event_to_event, event_key[1], Function[])
             # `from_event` is written by the user and calls `f` with possibly-enabled events.

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -98,12 +98,23 @@ event_types(gs::GeneratorSearch) = collect(keys(gs.event_to_event))
 
 place_patterns(gs::GeneratorSearch) = collect(keys(gs.byarray))
 
+"""
+    over_generated_events(callback, generators, physical, event_keys, changed_places)
+
+ * `callback` is a function in the main event loop of the framework that accepts
+   an event as an argument.
+ * `generators` is the struct containing all event generators.
+ * `physical` is physical state.
+ * `event_keys` is a vector or set of keys.
+ * `changed_places` is a vector or set of physical addresses.
+"""
 function over_generated_events(
     f::Function, generators::GeneratorSearch, physical, event_key, changed_places
 )
     if !isempty(event_key)
         event_args = event_key[2:end]
         for from_event in get(generators.event_to_event, event_key[1], Function[])
+            # `from_event` is written by the user and calls `f` with possibly-enabled events.
             from_event(f, physical, event_args...)
         end
     end
@@ -111,6 +122,7 @@ function over_generated_events(
     for place in changed_places
         placekey = placekey_mask_index(place)
         inds = [val for val in place if !isa(val, Member)]
+        # `genfunc` is written by the user and calls `f` with possibly-enabled events.
         for genfunc in get(generators.byarray, placekey, Function[])
             genfunc(f, physical, inds...)
         end

--- a/src/placetoevent.jl
+++ b/src/placetoevent.jl
@@ -3,7 +3,9 @@ struct EventDependency{CK}
     depnet::DependencyNetwork{CK}
     eventgen::GeneratorSearch
     seen::Set{SimEvent}
-    EventDependency{CK}(eventgen) = new(DependencyNetwork{CK}(), eventgen, Set{SimEvent}())
+    function EventDependency{CK}(eventgen) where {CK}
+        new(DependencyNetwork{CK}(), eventgen, Set{SimEvent}())
+    end
 end
 
 
@@ -59,7 +61,7 @@ function add_event!(net::EventDependency{E}, evtkey, enplaces, raplaces) where {
     add_event!(net.depnet, evtkey, enplaces, raplaces)
 end
 
-remove_event!(net::EventDependency{E}, evtkeys) where {E} = remove_event(net.depnet, evtkeys)
+remove_event!(net::EventDependency{E}, evtkeys) where {E} = remove_event!(net.depnet, evtkeys)
 
 getevent_enable(net::EventDependency{E}, event) where {E} = getevent_enable(net.depnet, event)
 

--- a/src/placetoevent.jl
+++ b/src/placetoevent.jl
@@ -1,11 +1,21 @@
 
+
+"""
+    EventDependency{ClockKey}(event_generator)
+
+Represents the dependency graph between the set of events and the set of
+physical states. It uses clock keys to represent events and physical addresses
+to represent the physical state. This struct combines dynamic event generation
+with a static graph in order to present to the framework a unified version of
+the bipartite graph of events and physical state. It could be replaced by a
+static graph of events and physical states, such as is used in generalized
+stochastic Petri nets (GSPN).
+"""
 struct EventDependency{CK}
     depnet::DependencyNetwork{CK}
     eventgen::GeneratorSearch
-    seen::Set{SimEvent}
-    function EventDependency{CK}(eventgen) where {CK}
-        new(DependencyNetwork{CK}(), eventgen, Set{SimEvent}())
-    end
+    seen::Set{CK}
+    EventDependency{CK}(eventgen) where {CK} = new(DependencyNetwork{CK}(), eventgen, Set{CK}())
 end
 
 
@@ -17,18 +27,19 @@ function over_event_invariants(
     @assert !isempty(changed_places)
 
     cond_affected = union((getplace_enable(dependency.depnet, cp) for cp in changed_places)...)
-    for cond in cond_affected
-        cond_evt = enabled_events[cond]
+    for cond_key in cond_affected
+        cond_evt = enabled_events[cond_key]
         cb(cond_evt)
-        push!(dependency.seen, cond_evt)
+        push!(dependency.seen, cond_key)
     end
 
     over_generated_events(
         dependency.eventgen, sim.physical, fired_event_keys, changed_places
     ) do newevent
-        if !in(newevent, dependency.seen)
+        newevent_key = clock_key(newevent)
+        if !in(newevent_key, dependency.seen)
             cb(newevent)
-            push!(dependency.seen, newevent)
+            push!(dependency.seen, newevent_key)
         end
     end
 end
@@ -46,12 +57,12 @@ function over_event_rates(
     @assert !isempty(changed_places)
 
     rate_affected = union((getplace_rate(dependency.depnet, cp) for cp in changed_places)...)
-    for rate in rate_affected
-        rate_evt = enabled_events[rate]
+    for rate_key in rate_affected
+        rate_evt = enabled_events[rate_key]
         # This is where this method depends on the `over_event_invariants` method.
-        if !in(rate_evt, dependency.seen)
+        if !in(rate_key, dependency.seen)
             cb(rate_evt)
-            push!(dependency.seen, rate_evt)
+            push!(dependency.seen, rate_key)
         end
     end
 end

--- a/src/placetoevent.jl
+++ b/src/placetoevent.jl
@@ -1,0 +1,66 @@
+
+struct EventDependency{CK}
+    depnet::DependencyNetwork{CK}
+    eventgen::GeneratorSearch
+    seen::Set{SimEvent}
+    EventDependency{CK}(eventgen) = new(DependencyNetwork{CK}(), eventgen, Set{SimEvent}())
+end
+
+
+function over_event_invariants(
+    cb::Function, dependency::EventDependency, sim, fired_event_keys, changed_places
+)
+    enabled_events = sim.enabled_events
+    empty!(dependency.seen)
+    @assert !isempty(changed_places)
+
+    cond_affected = union((getplace_enable(dependency.depnet, cp) for cp in changed_places)...)
+    for cond in cond_affected
+        cond_evt = enabled_events[cond]
+        cb(cond_evt)
+        push!(dependency.seen, cond_evt)
+    end
+
+    over_generated_events(
+        dependency.eventgen, sim.physical, fired_event_keys, changed_places
+    ) do newevent
+        if !in(newevent, dependency.seen)
+            cb(newevent)
+            push!(dependency.seen, newevent)
+        end
+    end
+end
+
+
+"""
+Note that this method requires a first call to `over_event_invariants` and that
+this method interacts with that call by excluding events that were iterated in
+`over_event_invariants`.
+"""
+function over_event_rates(
+    cb::Function, dependency::EventDependency, sim, fired_event_keys, changed_places
+)
+    enabled_events = sim.enabled_events
+    @assert !isempty(changed_places)
+
+    rate_affected = union((getplace_rate(dependency.depnet, cp) for cp in changed_places)...)
+    for rate in rate_affected
+        rate_evt = enabled_events[rate]
+        # This is where this method depends on the `over_event_invariants` method.
+        if !in(rate_evt, dependency.seen)
+            cb(rate_evt)
+            push!(dependency.seen, rate_evt)
+        end
+    end
+end
+
+
+function add_event!(net::EventDependency{E}, evtkey, enplaces, raplaces) where {E}
+    add_event!(net.depnet, evtkey, enplaces, raplaces)
+end
+
+remove_event!(net::EventDependency{E}, evtkeys) where {E} = remove_event(net.depnet, evtkeys)
+
+getevent_enable(net::EventDependency{E}, event) where {E} = getevent_enable(net.depnet, event)
+
+getevent_rate(net::EventDependency{E}, event) where {E} = getevent_rate(net.depnet, event)

--- a/src/placetoevent.jl
+++ b/src/placetoevent.jl
@@ -74,6 +74,8 @@ end
 
 remove_event!(net::EventDependency{E}, evtkeys) where {E} = remove_event!(net.depnet, evtkeys)
 
-getevent_enable(net::EventDependency{E}, event) where {E} = getevent_enable(net.depnet, event)
+function getevent_enable(net::EventDependency{E}, event_key) where {E}
+    getevent_enable(net.depnet, event_key)
+end
 
-getevent_rate(net::EventDependency{E}, event) where {E} = getevent_rate(net.depnet, event)
+getevent_rate(net::EventDependency{E}, event_key) where {E} = getevent_rate(net.depnet, event_key)

--- a/test/ChronoSimTests.jl
+++ b/test/ChronoSimTests.jl
@@ -9,6 +9,7 @@ continuous_integration() = get(ENV, "CI", "false") == "true"
 include("test_depnet.jl")
 include("test_elevator.jl")
 include("test_events.jl")
+include("test_framework.jl")
 include("test_generator_search.jl")
 include("test_generators.jl")
 include("test_obs_traits.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+# Run with: julia --project -e 'using Pkg;Pkg.test(;test_args=["framework"])'
+# Here, "framework" is a keyword in the name of the testset.
 using ArgParse
 
 include("ChronoSimTests.jl")

--- a/test/test_framework.jl
+++ b/test/test_framework.jl
@@ -1,0 +1,114 @@
+using ReTest
+using ChronoSim
+using CompetingClocks: FirstReaction
+
+const TestDealClockKey = Tuple{Int,Int}
+const TestDealAddressType = Symbol
+
+mutable struct TestDealEvent <: SimEvent
+    key::TestDealClockKey
+    prev_enabled::Bool
+    enabled::Bool
+    prev_invariant::Set{TestDealAddressType}
+    invariant::Set{TestDealAddressType}
+    prev_rate::Set{TestDealAddressType}
+    rate::Set{TestDealAddressType}
+    rerate::Set{TestDealAddressType}
+    called_precondition::Int
+    called_event_enable::Int
+    called_event_reenable::Int
+end
+
+
+ChronoSim.clock_key(event::TestDealEvent) = event.key
+
+function ChronoSim.generators(::Type{TestDealEvent})
+    [EventGenerator(ChronoSim.ToPlace, Any[], x -> nothing)]
+end
+
+"""
+The three `sim_event_*` functions call user-defined code, so we separate this
+out in order to check the calls and return values.
+"""
+function ChronoSim.sim_event_precondition(event::TestDealEvent, physical)
+    event.called_precondition += 1
+    return (; result=event.enabled, reads=event.invariant)
+end
+
+
+function ChronoSim.sim_event_enable(event::TestDealEvent, event_key, sim, when)
+    event.called_event_enable += 1
+    return (; reads=event.rate)
+end
+
+
+function ChronoSim.sim_event_reenable(event::TestDealEvent, event_key, sim)
+    event.called_event_reenable += 1
+    return event.rate
+end
+
+ChronoSim.ObservedState.@observedphysical TestDealSystem begin
+    car::Int
+    truck::Int
+    bicycle::Int
+    moped::Int
+    skateboard::Int
+end
+
+const TestDealAddType = Tuple{Set{TestDealAddressType},Set{TestDealAddressType}}
+
+struct TestDealEventDependency
+    invariants::Vector{TestDealEvent}
+    rates::Vector{TestDealEvent}
+    added::Dict{TestDealClockKey,TestDealAddType}
+end
+
+function ChronoSim.over_event_invariants(
+    f::Function, event_dependency, sim, fired_event_keys, changed_places
+)
+    for v in event_dependency.invariants
+        f(v)
+    end
+end
+
+function ChronoSim.over_event_rates(
+    f::Function, event_dependency, sim, fired_event_keys, changed_places
+)
+    for r in event_dependency.rates
+        f(r)
+    end
+end
+
+function ChronoSim.add_event!(
+    event_dependency::TestDealEventDependency, evt_key, enplaces, raplaces
+)
+    event_dependency.added[evt_key] = (enplaces, raplaces)
+end
+
+@testset "framework deal_with_changes smoke" begin
+    event = TestDealEvent(
+        (3, 7),
+        false,
+        true,
+        Set(Symbol[]),
+        Set([:car, :truck]),
+        Set(Symbol[]),
+        Set([:car, :moped]),
+        Set([:nope]),
+        0,
+        0,
+        0,
+    )
+    event_dependency = TestDealEventDependency(
+        TestDealEvent[event], TestDealEvent[], Dict{TestDealClockKey,TestDealAddType}()
+    )
+    physical = TestDealSystem(0, 0, 0, 0, 0)
+    event_list = [TestDealEvent]
+    sampler = FirstReaction{TestDealClockKey,Float64}()
+    sim = SimulationFSM(physical, event_list; sampler=sampler)
+    changed_places = Set([:car])
+    ChronoSim.deal_with_changes(sim, event_dependency, [], changed_places)
+    @test event.called_event_enable == 1
+    @test event_dependency.added[(3, 7)][1] == Set([:car, :truck])
+    @test event_dependency.added[(3, 7)][2] == Set([:car, :moped])
+end

--- a/test/test_framework.jl
+++ b/test/test_framework.jl
@@ -3,6 +3,41 @@ using Distributions
 using ChronoSim
 using CompetingClocks: FirstReaction, enable!
 
+
+struct TestFrameworkEvent <: SimEvent end
+
+@testset "framework invoke user code happy" begin
+    val = ChronoSim.invoke_user_code("frameworktest", TestFrameworkEvent()) do
+        3
+    end
+    @test val == 3
+end
+
+@testset "framework invoke user code sad" begin
+    testf() =
+        ChronoSim.invoke_user_code("frameworktest", TestFrameworkEvent()) do
+            div(3, 0)
+        end
+    @test_throws ChronoSim.ModelDefinitionError testf()
+end
+
+@testset "framework invoke user code examine" begin
+    testf() =
+        ChronoSim.invoke_user_code("frameworktest", TestFrameworkEvent()) do
+            div(3, 0)
+        end
+    try
+        testf()
+    catch e
+        if e isa ChronoSim.ModelDefinitionError
+            @test e.context == "frameworktest"
+            @test e.event_type == TestFrameworkEvent
+        else
+            rethrow()
+        end
+    end
+end
+
 const TestDealClockKey = Tuple{Int,Int}
 const TestDealAddressType = Symbol
 

--- a/test/test_framework.jl
+++ b/test/test_framework.jl
@@ -5,6 +5,40 @@ using CompetingClocks: FirstReaction, enable!
 
 
 struct TestFrameworkEvent <: SimEvent end
+struct TestFrameworkAnotherEvent <: SimEvent end
+struct TestFrameworkIntEvent <: SimEvent
+    val::Int
+end
+struct TestFrameworkIntBEvent <: SimEvent
+    some::Int
+end
+struct TestFrameworkSymbolEvent <: SimEvent
+    sym::Symbol
+end
+struct TestFrameworkIntFloatEvent <: SimEvent
+    val::Int
+    other::Float64
+end
+
+@testset "framework common_base_key_tuple smoke" begin
+    v = ChronoSim.common_base_key_tuple([TestFrameworkEvent, TestFrameworkAnotherEvent])
+    @test v == Tuple{Symbol}
+    v = ChronoSim.common_base_key_tuple([TestFrameworkIntEvent, TestFrameworkIntBEvent])
+    @test v == Tuple{Symbol,Int}
+    v = ChronoSim.common_base_key_tuple([TestFrameworkIntEvent, TestFrameworkIntFloatEvent])
+    @test v == Tuple{Symbol,Int64,Vararg{Float64}}
+    v = ChronoSim.common_base_key_tuple([
+        TestFrameworkIntEvent, TestFrameworkIntFloatEvent, TestFrameworkEvent
+    ])
+    @test v == Tuple{Symbol,Vararg{Real}}
+    v = ChronoSim.common_base_key_tuple([
+        TestFrameworkIntEvent,
+        TestFrameworkIntFloatEvent,
+        TestFrameworkEvent,
+        TestFrameworkSymbolEvent,
+    ])
+    @test v == Tuple{Symbol,Vararg{Any}}
+end
 
 @testset "framework invoke user code happy" begin
     val = ChronoSim.invoke_user_code("frameworktest", TestFrameworkEvent()) do

--- a/test/test_framework.jl
+++ b/test/test_framework.jl
@@ -245,7 +245,83 @@ end
     @test event.called_event_enable == 0
     @test event.called_event_reenable == 1
     @test (3, 7) ∈ keys(event_dependency.added)
-    @test event_dependency.added[1] == Set([:car, :bicycle])
-    @test event_dependency.added[2] == Set([:car, :moped])
+    @test event_dependency.added[(3, 7)][1] == Set([:car, :bicycle])
+    @test event_dependency.added[(3, 7)][2] == Set([:car, :moped])
+    @test (3, 7) ∉ event_dependency.removed
+end
+
+
+@testset "framework deal_with_changes reenable same invariant yes reenable" begin
+    # Re-enabling but because the invariant changed, recalculate rates.
+    event = TestDealEvent(
+        (3, 7),
+        true, # was enabled
+        true, # is enabled
+        Set([:car, :truck]), # invariant before
+        Set([:car, :truck]), # invariant now
+        Set([:car, :moped]), # rate before
+        Set([:car, :moped]), # rate now
+        Set([:car, :moped]), # reenable dependencies
+        0,
+        0,
+        0,
+    )
+    event_dependency = TestDealEventDependency(TestDealEvent[event], TestDealEvent[])
+    physical = TestDealSystem(0, 0, 0, 0, 0)
+    event_list = [TestDealEvent]
+    sampler = FirstReaction{TestDealClockKey,Float64}()
+    sim = SimulationFSM(physical, event_list; sampler=sampler)
+    if event.prev_enabled
+        enable!(sampler, clock_key(event), Exponential(), 0.0, 0.0, sim.rng)
+        sim.enabled_events[clock_key(event)] = event
+        sim.enabling_times[clock_key(event)] = sim.when
+    end
+    # Here we say that the place that changed IS something the rate depends on.
+    changed_places = Set([:car])
+    ChronoSim.deal_with_changes(sim, event_dependency, [], changed_places)
+    @test event.called_precondition == 1
+    @test event.called_event_enable == 0
+    @test event.called_event_reenable == 1
+    # It won't be in added because the rate dependencies didn't change.
+    @test (3, 7) ∉ keys(event_dependency.added)
+    @test (3, 7) ∉ event_dependency.removed
+end
+
+
+@testset "framework deal_with_changes reenable same invariant yes reenable added" begin
+    # Re-enabling but because the invariant changed, recalculate rates.
+    event = TestDealEvent(
+        (3, 7),
+        true, # was enabled
+        true, # is enabled
+        Set([:car, :truck]), # invariant before
+        Set([:car, :truck]), # invariant now
+        Set([:car, :moped]), # rate before
+        Set([:car, :moped]), # rate now
+        Set([:car, :moped, :bicycle]), # reenable dependencies
+        0,
+        0,
+        0,
+    )
+    event_dependency = TestDealEventDependency(TestDealEvent[event], TestDealEvent[])
+    physical = TestDealSystem(0, 0, 0, 0, 0)
+    event_list = [TestDealEvent]
+    sampler = FirstReaction{TestDealClockKey,Float64}()
+    sim = SimulationFSM(physical, event_list; sampler=sampler)
+    if event.prev_enabled
+        enable!(sampler, clock_key(event), Exponential(), 0.0, 0.0, sim.rng)
+        sim.enabled_events[clock_key(event)] = event
+        sim.enabling_times[clock_key(event)] = sim.when
+    end
+    # Here we say that the place that changed IS something the rate depends on.
+    changed_places = Set([:car])
+    ChronoSim.deal_with_changes(sim, event_dependency, [], changed_places)
+    @test event.called_precondition == 1
+    @test event.called_event_enable == 0
+    @test event.called_event_reenable == 1
+    # It will be in added dependencies because it changed.
+    @test (3, 7) ∈ keys(event_dependency.added)
+    @test event_dependency.added[(3, 7)][1] == Set([:car, :truck])
+    @test event_dependency.added[(3, 7)][2] == Set([:car, :moped, :bicycle])
     @test (3, 7) ∉ event_dependency.removed
 end


### PR DESCRIPTION
The main goal is to simplify and test how the framework deals with the results of firing an event.

- Simplifed `deal_with_events`.
- Deleted the part that dealt with generated events separately.
- Made a single interface over generated and recorded events so that we can make a static dependency graph later.
- Tested the new `deal_with_events` for all decisions and branches.
- Tested how we catch errors in model code.
- Tested how we unify the event types to make a single type to use internal to the framework.
