### PR TITLE
Notify vacated tail slot in ObservedVector popfirst!

### DIFF
--- a/src/ObservedState/observed_vector.jl
+++ b/src/ObservedState/observed_vector.jl
@@ -204,8 +204,12 @@ function _popfirst!(::PrimitiveTrait, v::ObservedVector)
     if isempty(v.arr)
         throw(BoundsError(v, ()))
     end
+    # Every old slot 1:old_length changes denotation: 1:old_length-1 hold shifted
+    # contents and the tail slot old_length is vacated to ⊥. Notifying only the
+    # surviving indices would leak the vacated tail, leaving events keyed on it enabled.
+    old_length = length(v.arr)
     x = popfirst!(v.arr)
-    for i in eachindex(v.arr)
+    for i in 1:old_length
         observed_notify(v, (i,), :write)
     end
     return x
@@ -215,9 +219,14 @@ function _popfirst!(::CompoundTrait, v::ObservedVector)
     if isempty(v.arr)
         throw(BoundsError(v, ()))
     end
+    old_length = length(v.arr)
     x = popfirst!(v.arr)
+    # Notify the vacated tail slot through the removed element re-addressed to it,
+    # mirroring _pop!'s notify-then-empty. Without this the tail slot leaks.
+    _update_index(x, v, old_length)
+    notify_all(x)
     empty!(x._address)
-    # Update indices for remaining elements
+    # Update indices for remaining elements, which each shifted down one slot.
     for i in eachindex(v.arr)
         element = v.arr[i]
         _update_index(element, v, i)

--- a/test/test_observed_array.jl
+++ b/test/test_observed_array.jl
@@ -229,6 +229,39 @@ using ChronoSim.ObservedState
         @test length(base.seen) > initial_notifications
     end
 
+    @testset "popfirst! notifies the vacated tail slot" begin
+        # Regression: the old tail slot's denotation changes to nothing, so it must
+        # be notified. Previously only the surviving indices 1:n-1 were notified,
+        # leaking the vacated slot n.
+        arr = ObservedVector{Int,Member}([10, 20, 30])
+        base = ObsArrayListen(Any[])
+        ChronoSim.ObservedState.update_index(arr._address, base, Member(:myarray))
+
+        popfirst!(arr)
+
+        written = sort(unique([s[1][2] for s in base.seen if s[2] == :write]))
+        @test written == [1, 2, 3]  # slot 3 (the vacated tail) must appear
+    end
+
+    @testset "popfirst! notifies the vacated tail slot for compound elements" begin
+        Contained1D = ObserveContained{Int}
+        arr = ObservedArray{Contained1D,Member}(undef, 3)
+        for i in eachindex(arr)
+            arr[i] = Contained1D(-i)
+        end
+        base = ObsArrayListen(Any[])
+        ChronoSim.ObservedState.update_index(arr._address, base, Member(:myarray))
+
+        popfirst!(arr)
+
+        # Compound notifications are field-granular: (Member(:myarray), index, Member(field)).
+        # The vacated tail slot (old length 3) must be among them.
+        tail_notified = any(
+            s -> s[2] == :write && length(s[1]) >= 2 && s[1][2] == 3, base.seen
+        )
+        @test tail_notified
+    end
+
     @testset "ObservedVector append!" begin
         arr = ObservedVector{Int,Member}([1, 2])
         base = ObsArrayListen(Any[])


### PR DESCRIPTION
## Problem

`ObservedVector`'s read/write notification contract (C1) requires that any mutation notify a superset of the addresses whose *denotation* changed. `popfirst!` shifts every surviving element down one slot **and** vacates the old tail slot `n` (its denotation changes from "element n's fields" to nothing). Both variants of `_popfirst!` iterated `eachindex(v.arr)` *after* the pop — i.e. `1:(n-1)` — so the vacated tail slot `n` was never notified.

Consequence: an event keyed on the old tail slot (e.g. an index-parameterized event on position `n`) is never re-checked after a `popfirst!` and can stay enabled against a dead slot. `_pop!` already notifies its vacated slot correctly; this was an asymmetry between the two.

This was surfaced during a design review of the `ObservedState` addressing scheme (the "vacated-tail leak").

## Fix

- **Primitive elements:** capture `old_length` before popping and notify `1:old_length`, so the vacated tail slot is included.
- **Compound elements:** notify the vacated tail slot through the removed element re-addressed to that slot (`_update_index` → `notify_all` → `empty!`), mirroring `_pop!`'s notify-then-empty. Surviving elements are still re-indexed and notified as before.

## Tests

Added two regression tests (`popfirst!` for primitive and compound element types) asserting the vacated tail slot appears in the write notifications. Full suite passes (22739 tests), including the elevator TLC trace validation.

## Not addressed here (out of scope)

The same review flagged related `ObservedVector` gaps — the ABA hazard (no generation counter on slot reuse) and unwrapped structural mutators (`deleteat!`, `insert!`, `splice!`, `sort!`, …) that fall through to `Base` and can break the element-address invariant silently. Those are larger design changes and left for follow-up.