### PR TITLE
Accept undef arrays in ObservedArray constructor (fixes Julia 1.13 UndefRefError)

### DIFF
--- a/src/ObservedState/observed_vector.jl
+++ b/src/ObservedState/observed_vector.jl
@@ -4,6 +4,13 @@ export ObservedArray, ObservedVector, ObservedMatrix
 mutable struct ObservedArray{T,N,Index} <: DenseArray{T,N}
     const arr::Array{T,N}
     _address::Address{Index}
+    # copy() does a raw buffer copy that leaves undefined references intact, so an
+    # array allocated with `undef` and filled by the caller afterward is accepted.
+    # collect() dereferences every slot and throws UndefRefError on such arrays
+    # (element-wise since Julia 1.13); the generic method below keeps collect() for
+    # non-Array iterables such as generators, whose elements are always defined.
+    ObservedArray{T,N,Index}(arr::Array{T,N}) where {T,N,Index} =
+        new{T,N,Index}(copy(arr), Address{Index}())
     ObservedArray{T,N,Index}(arr) where {T,N,Index} = new{T,N,Index}(collect(arr), Address{Index}())
 end
 

--- a/test/test_observed_array.jl
+++ b/test/test_observed_array.jl
@@ -94,6 +94,31 @@ using ChronoSim.ObservedState
     end
 
 
+    @testset "undef construction of a reference element type is allowed" begin
+        # Regression: the constructor must not dereference the undefined slots of an
+        # `undef` array whose element type is a mutable (reference) struct. collect()
+        # does so and throws UndefRefError element-wise on Julia >= 1.13; copy() does
+        # not. This is the pattern ElevatorSystem uses (see test/elevator.jl).
+        using ChronoSim.ObservedState
+        Contained1D = ObserveContained{Int}
+        cnt = 4
+        arr = ObservedArray{Contained1D,Member}(undef, cnt)
+        for i in eachindex(arr)
+            arr[i] = Contained1D(-i)
+        end
+        @test length(arr) == cnt
+        @test [arr[i].val for i in 1:cnt] == [-1, -2, -3, -4]
+
+        # Same for a 2D array of reference elements (index is a 2-tuple).
+        Contained2D = ObserveContained{NTuple{2,Int64}}
+        mat = ObservedArray{Contained2D,Member}(undef, 2, 2)
+        for idx in CartesianIndices(mat)
+            mat[idx] = Contained2D(sum(Tuple(idx)))
+        end
+        @test size(mat) == (2, 2)
+        @test mat[2, 2].val == 4
+    end
+
     @testset "ObservedState 1D push!" begin
         using ChronoSim.ObservedState
         Contained1D = ObserveContained{Int}


### PR DESCRIPTION
## Symptom

On the `Julia pre` (1.13.0-rc1) CI job, the elevator smoke test errors during construction:

```
UndefRefError: access to undefined reference
 [4] collect @ ./array.jl:761
 [5] ObservedArray @ src/ObservedState/observed_vector.jl:7
 [7] ElevatorSystem(...) @ test/elevator.jl:56
```

## Cause

The `ObservedArray` inner constructor materialized its argument with `collect(arr)`:

```julia
ObservedArray{T,N,Index}(arr) where {T,N,Index} = new{T,N,Index}(collect(arr), Address{Index}())
```

`ElevatorSystem` builds `ObservedArray{Person,Member}(undef, person_cnt)`, which allocates `Array{Person}(undef, n)` — an array of a **mutable (reference)** element type with **undefined slots** — and hands it to that constructor. `collect` copies element-by-element, dereferencing each slot.

- **Julia ≤ 1.12** collected an `Array` via a raw-buffer fast path that never touched the slots, so the undefined references were copied harmlessly and the bug stayed latent.
- **Julia 1.13** collects `Array`s element-wise (`_collect_indices` → `copyto_unaliased!` → `getindex`), so it dereferences the undefined slots and throws `UndefRefError`.

This is unrelated to the `popfirst!` fix in #21 and to the `actions/checkout` bump in #18 — the action bump just re-ran CI against the newer prerelease that exposed it. Reproduced directly on Julia 1.13.0-beta1: `collect(Array{Foo}(undef, 3))` throws `UndefRefError`, while `copy(...)` does not.

## Fix

Add an inner constructor specialized on `Array{T,N}` that copies via `copy()` — a raw buffer copy that leaves undefined references intact — and keep `collect()` for non-`Array` iterables (generators, ranges), whose elements are always defined:

```julia
ObservedArray{T,N,Index}(arr::Array{T,N}) where {T,N,Index} =
    new{T,N,Index}(copy(arr), Address{Index}())
ObservedArray{T,N,Index}(arr) where {T,N,Index} =
    new{T,N,Index}(collect(arr), Address{Index}())
```

`copy` still makes an independent defensive copy, so array-input construction keeps its previous semantics (verified: mutating the source array does not affect the `ObservedArray`).

## Verification

- **Julia 1.13.0-beta1** (local, reproduces the CI failure): the exact `ObservedArray{Person,Member}(undef, n)` + fill pattern now succeeds; generator and array-input constructors still work; 1D and 2D undef reference-element arrays build correctly.
- **Julia 1.12.4**: full suite passes (22743), no regression.
- Added a regression test (`undef construction of a reference element type is allowed`) covering 1D and 2D undef arrays of a reference element type.

## Note

CI will still show the pre-existing Aqua "Persistent tasks" flake and the missing-TLA-jar noise discussed on #21; those are separate from this fix.